### PR TITLE
Add Maven support and remove unused imports

### DIFF
--- a/dev-tools/maven/lucene/monitor/pom.xml.template
+++ b/dev-tools/maven/lucene/monitor/pom.xml.template
@@ -1,0 +1,70 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+  
+  http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.lucene</groupId>
+    <artifactId>lucene-parent</artifactId>
+    <version>@version@</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+  <groupId>org.apache.lucene</groupId>
+  <artifactId>lucene-monitor</artifactId>
+  <packaging>jar</packaging>
+  <name>Lucene Monitor</name>
+  <description>
+    High-performance single-document index to compare against Query
+  </description>
+  <properties>
+    <module-directory>lucene/monitor</module-directory>
+    <relative-top-level>../../..</relative-top-level>
+    <module-path>${relative-top-level}/${module-directory}</module-path>
+  </properties>
+  <scm>
+    <connection>scm:git:${vc-anonymous-base-url}</connection>
+    <developerConnection>scm:git:${vc-dev-base-url}</developerConnection>
+    <url>${vc-browse-base-url};f=${module-directory}</url>
+  </scm>
+  <dependencies>
+    <dependency> 
+      <!-- lucene-test-framework dependency must be declared before lucene-core -->
+      <groupId>org.apache.lucene</groupId>
+      <artifactId>lucene-test-framework</artifactId>
+      <scope>test</scope>
+    </dependency>
+@lucene-monitor.internal.dependencies@
+@lucene-monitor.external.dependencies@
+@lucene-monitor.internal.test.dependencies@
+@lucene-monitor.external.test.dependencies@
+  </dependencies>
+  <build>
+    <sourceDirectory>${module-path}/src/java</sourceDirectory>
+    <testSourceDirectory>${module-path}/src/test</testSourceDirectory>
+    <testResources>
+      <testResource>
+        <directory>${project.build.testSourceDirectory}</directory>
+        <excludes>
+          <exclude>**/*.java</exclude>
+        </excludes>
+      </testResource>
+    </testResources>
+  </build>
+</project>

--- a/dev-tools/maven/lucene/pom.xml.template
+++ b/dev-tools/maven/lucene/pom.xml.template
@@ -55,6 +55,7 @@
     <module>join</module>
     <module>memory</module>
     <module>misc</module>
+    <module>monitor</module>
     <module>queries</module>
     <module>queryparser</module>
     <module>replicator</module>

--- a/lucene/monitor/src/java/org/apache/lucene/monitor/Monitor.java
+++ b/lucene/monitor/src/java/org/apache/lucene/monitor/Monitor.java
@@ -28,7 +28,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.function.BiPredicate;
 
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.document.Document;
@@ -40,7 +39,6 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.Weight;
-import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.NamedThreadFactory;
 
 /**

--- a/lucene/monitor/src/java/org/apache/lucene/monitor/MultiMatchingQueries.java
+++ b/lucene/monitor/src/java/org/apache/lucene/monitor/MultiMatchingQueries.java
@@ -21,7 +21,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * Class to hold the results of matching a batch of {@link org.apache.lucene.document.Document}s

--- a/lucene/monitor/src/java/org/apache/lucene/monitor/QueryMatch.java
+++ b/lucene/monitor/src/java/org/apache/lucene/monitor/QueryMatch.java
@@ -17,11 +17,8 @@
 
 package org.apache.lucene.monitor;
 
-import java.io.IOException;
-import java.util.Map;
 import java.util.Objects;
 
-import org.apache.lucene.search.Query;
 import org.apache.lucene.search.Scorable;
 import org.apache.lucene.search.ScoreMode;
 

--- a/lucene/monitor/src/test/org/apache/lucene/monitor/ConcurrentMatcherTestBase.java
+++ b/lucene/monitor/src/test/org/apache/lucene/monitor/ConcurrentMatcherTestBase.java
@@ -17,7 +17,6 @@
 
 package org.apache.lucene.monitor;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
@@ -27,12 +26,8 @@ import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
-import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.util.LuceneTestCase;
 import org.apache.lucene.util.NamedThreadFactory;
-
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.core.IsNot.not;
 
 public abstract class ConcurrentMatcherTestBase extends LuceneTestCase {
 


### PR DESCRIPTION
Mix of 2 commits here, the first adds maven support (so the monitor library is built alongside all the other maven artifacts), and the second fixes a bunch of errors Eclipse gave me about unused imports.